### PR TITLE
Fixed Patreon Link (Needs Review)

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
                         </button>
                     </a>
 
-                    <a href="https://www.patreon.com/miaberth" target="_blank" draggable="false">
+                    <a href="https://www.patreon.com/berthrage" target="_blank" draggable="false">
                         <button class="btn-redirect-patreon">
                             <span>PATREON</span>
                             <div style="width: 100%">


### PR DESCRIPTION
The link was previously going to `miaberth` which gives a 404 on Patreon. 

![image](https://github.com/user-attachments/assets/49a18f7f-456e-4ce3-a73c-fb4d046e33b4)

Searching for `berthrage` in Patreon gave me this link. https://www.patreon.com/berthrage

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/946fc924-301d-492e-8090-49722e71a59c" />

The profile image matches you're GithHub Profile.

<img width="675" alt="image" src="https://github.com/user-attachments/assets/31974c38-c191-4150-8950-16f645febee4" />

<hr>

That being said I **don't know** if it's impersonation so please verify the changes and only proceed with merging if it looks good.